### PR TITLE
fix: Don't transform properly formed :host selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = postcss.plugin('postcss-host', function () {
  * @return {Boolean}
  */
 function isHostSelector(selector) {
-  return /\:host/.test(selector);
+  return /\:host[^(]/.test(selector);
 }
 
 /**

--- a/test/dist/index.css
+++ b/test/dist/index.css
@@ -25,3 +25,15 @@
 .foo:hover {
   background: yellow;
 }
+
+:host(:hover) {
+  background: aqua;
+}
+
+:host(.className) {
+  background: white;
+} 
+
+:host(custom-element) {
+  background: black;
+}

--- a/test/src/index.css
+++ b/test/src/index.css
@@ -25,3 +25,15 @@
 .foo:hover {
   background: yellow;
 }
+
+:host(:hover) {
+  background: aqua;
+}
+
+:host(.className) {
+  background: white;
+} 
+
+:host(custom-element) {
+  background: black;
+}


### PR DESCRIPTION
Hi again @vitkarpov, sorry for the quick succession of PRs, but I noticed that I introduced a bug where properly formed `:host` selectors were incorrectly being transformed again 😞

I've made the fix, and added tests to prevent any future regressions.

Thanks again!